### PR TITLE
PleaseTestParamAndTableSelectChanges

### DIFF
--- a/fetchit7.constants.inc
+++ b/fetchit7.constants.inc
@@ -47,7 +47,7 @@ define("F_DR_FIELD_TITLE_STR","title");
 define("F_DR_FIELD_DESC_STR","desc");
 define("F_DR_FIELD_INPUT_TYPE_STR","input_type");
 define("F_DR_FIELD_DEFAULT_STR","default");
-define("F_DR_FIELD_DEFAULT_CHAR_STR","default_char");
+define("FETCHIT7_ALLNONE_SPECIAL_CHAR_STR","allnone_specialcharacter");
 define("F_DR_FIELD_DISABLED_STR","disabled");
 define("F_DR_FIELD_REQUIRED_STR","required");
 define("F_DR_FIELD_VALIDATE_STR","validate");
@@ -58,7 +58,8 @@ define("FETCHIT7_FIELD_HIDDEN_STR","hidden");
 
 // these are the array keys used for field input list table parameters
 define("F_DR_FIELD_LIST_TBL_STR","list_tbl");
-define("F_DR_FIELD_LIST_TBL_CHAR_STR","list_tbl_char");
+//define("F_DR_FIELD_LIST_TBL_CHAR_STR","list_tbl_char");
+define("FETCHIT7_DEFAULT_SPECIAL_CHAR_STR","default_specialcharacter");
 define("FETCHIT7_FIELD_LIST_NDX_STR","list_ndx"); //define("F_DR_LIST_TBL_NDX_FLD","stored");
 define("FETCHIT7_FIELD_LIST_DSP_STR","list_dsp"); //define("F_DR_LIST_TBL_DSP_FLD","displayed");
 define("F_DR_FIELD_LIST_UID_STR","list_uid"); //define("F_DR_LIST_TBL_UID_FLD","drupal_userid");

--- a/fetchit7.constants.inc
+++ b/fetchit7.constants.inc
@@ -47,6 +47,7 @@ define("F_DR_FIELD_TITLE_STR","title");
 define("F_DR_FIELD_DESC_STR","desc");
 define("F_DR_FIELD_INPUT_TYPE_STR","input_type");
 define("F_DR_FIELD_DEFAULT_STR","default");
+define("F_DR_FIELD_DEFAULT_CHAR_STR","default_char");
 define("F_DR_FIELD_DISABLED_STR","disabled");
 define("F_DR_FIELD_REQUIRED_STR","required");
 define("F_DR_FIELD_VALIDATE_STR","validate");
@@ -57,6 +58,7 @@ define("FETCHIT7_FIELD_HIDDEN_STR","hidden");
 
 // these are the array keys used for field input list table parameters
 define("F_DR_FIELD_LIST_TBL_STR","list_tbl");
+define("F_DR_FIELD_LIST_TBL_CHAR_STR","list_tbl_char");
 define("FETCHIT7_FIELD_LIST_NDX_STR","list_ndx"); //define("F_DR_LIST_TBL_NDX_FLD","stored");
 define("FETCHIT7_FIELD_LIST_DSP_STR","list_dsp"); //define("F_DR_LIST_TBL_DSP_FLD","displayed");
 define("F_DR_FIELD_LIST_UID_STR","list_uid"); //define("F_DR_LIST_TBL_UID_FLD","drupal_userid");

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1134,15 +1134,12 @@ function fetchit7_param_form($form, &$form_state) {
         $j++;
       }
       //debug($data_tbl_ndx_type,'fetchit7_param_form $data_tbl_ndx_type');
-      if (strlen(trim($data_tbl_ndx_type))) {// if we have a type, then an index field was found, and then we can continue building the parameter input control
+      // if we have a type, then an index field was found,
+      //   and then we can continue building the parameter input control
+      if (strlen(trim($data_tbl_ndx_type))) {
         $grp_ndx = 0;
+        //create a unique element name string
         $element_name = fetchit_make_element_name($nid, $grp_ndx, $param_count);
-		if (variable_get($element_name.'_value',FALSE)) {
-			// need to reset this control to an interim saved state
-			debug(variable_get($element_name.'_value',FALSE),'saved element '.$element_name.' value is:');
-			variable_set($element_name.'_value',NULL);
-		}
-        $user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_ALL;
         // set a default value to pass into the element generator
         // this value is used unless the user specified a default value in the configuration
         // get the last entered value from the selection table
@@ -1151,7 +1148,20 @@ function fetchit7_param_form($form, &$form_state) {
           case F_DR_CONTROL_CHECKBOXES:
           case F_DR_CONTROL_DROPDOWN_MULTI:
             $db_value = fetchit_get_existing_selection_multiple($db_handle, $db_type, $data_tbl, $data_ndx, $data_uid);
+            //check to see if there is an "interim state" we need to reset the control too
+	        //(in other words, the user hit a select All or select None button)
+	        //see if there is a stored variable with the name element_name_value
+			if (variable_get($element_name.'_value',FALSE)) {
+				// need to reset this control to an interim saved state
+				// set the default string to '' and then set the $db_value to the interim state
+        		$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]='';
+				debug(variable_get($element_name.'_value',FALSE),'saved element '.$element_name.' value is:');
+				$db_value = variable_get($element_name.'_value',FALSE);
+				//and then finally erase the interim state flag...
+				variable_set($element_name.'_value',NULL);
+			}
             // also here is where we change the default if the all or none buttons were pressed
+            //   for this particular element
             if (variable_get($element_name.'_allbtn',FALSE)) {
             	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_ALL;
             	//do the following in the submit button submit function
@@ -1293,7 +1303,7 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 			$element_name = $element_name_components[0].'_'.$element_name_components[1].'_'.$element_name_components[2].'_'.$element_name_components[3].'_'.$param_ndx;
 			variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
 		}
-		//$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
+		$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 	} else {
 		//debug($form_state['triggering_element']['#name'],'Hello from the fetchit7_param_form_force_triggering_element function. element name:');
 	}

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -973,10 +973,12 @@ function fetchit7_param_form($form, &$form_state) {
       }
       else {
         $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
+        $user_field_data[$field_index][FETCHIT7_ALLNONE_SPECIAL_CHAR_STR] = '';
       }
     }
     else {
       $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
+      $user_field_data[$field_index][FETCHIT7_ALLNONE_SPECIAL_CHAR_STR] = '';
     }
 
     //$param_data_tbl F_DR_FIELD_DATA_TBL_STR
@@ -1135,7 +1137,12 @@ function fetchit7_param_form($form, &$form_state) {
       if (strlen(trim($data_tbl_ndx_type))) {// if we have a type, then an index field was found, and then we can continue building the parameter input control
         $grp_ndx = 0;
         $element_name = fetchit_make_element_name($nid, $grp_ndx, $param_count);
-
+		if (variable_get($element_name.'_value',FALSE)) {
+			// need to reset this control to an interim saved state
+			debug(variable_get($element_name.'_value',FALSE),'saved element '.$element_name.' value is:');
+			variable_set($element_name.'_value',NULL);
+		}
+        $user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_ALL;
         // set a default value to pass into the element generator
         // this value is used unless the user specified a default value in the configuration
         // get the last entered value from the selection table
@@ -1144,6 +1151,43 @@ function fetchit7_param_form($form, &$form_state) {
           case F_DR_CONTROL_CHECKBOXES:
           case F_DR_CONTROL_DROPDOWN_MULTI:
             $db_value = fetchit_get_existing_selection_multiple($db_handle, $db_type, $data_tbl, $data_ndx, $data_uid);
+            // also here is where we change the default if the all or none buttons were pressed
+            if (variable_get($element_name.'_allbtn',FALSE)) {
+            	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_ALL;
+            	//do the following in the submit button submit function
+            	//variable_set($element_name.'_allbtn',FALSE);
+            }
+            if (variable_get($element_name.'_nonebtn',FALSE)) {
+            	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_NONE;
+            	//do the following in the submit button submit function
+            	//variable_set($element_name.'_nonebtn',FALSE);
+            }
+            // only need to make these if it is this type of control
+            // be sure to check isset in theme function, though
+	        $form['elements'][$element_name.'_allbtn'] = array(
+	        		'#type' => 'submit',
+	        		'#name' => $element_name.'_allbtn',
+	        		'#validate' => array(
+	        				'fetchit7_param_all_validate'
+	        		),
+	        		'#submit' => array(
+	        				'fetchit7_param_all_submit'
+	        		),
+	        		'#buttontype' => 'button',
+	        		'#value' => t('All'),
+	        );
+	        $form['elements'][$element_name.'_nonebtn'] = array(
+	        		'#type' => 'submit',
+	        		'#name' => $element_name.'_nonebtn',
+	        		'#validate' => array(
+	        				'fetchit7_param_none_validate'
+	        		),
+	        		'#submit' => array(
+	        				'fetchit7_param_none_submit'
+	        		),
+	        		'#buttontype' => 'button',
+	        		'#value' => t('None'),
+	        );
             break;
           case F_DR_CONTROL_DROPDOWN_SINGLE:
           case F_DR_CONTROL_RADIOBTN:
@@ -1169,7 +1213,8 @@ function fetchit7_param_form($form, &$form_state) {
         $form['param_data_table'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][F_DR_FIELD_DATA_TBL_STR]);
         $form['param_data_ndx'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][F_DR_FIELD_DATA_KEY_STR]);
         $form['param_data_uid'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][F_DR_FIELD_DATA_UID_STR]);
-
+        $form['param_allnone'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][FETCHIT7_ALLNONE_SPECIAL_CHAR_STR]);
+        
         // the following creates the "renderable array" of the next parameter input control (drupal form element)
         //   to be displayed on this form ($nid)
         // stack these up in the array. "How" they are to be displayed will be handled by the theme function
@@ -1236,6 +1281,23 @@ function fetchit7_param_form($form, &$form_state) {
 }
 
 function fetchit7_param_form_force_triggering_element($form, &$form_state) {
+	if(isset($form_state['triggering_element']['#name'])) {
+		debug($form_state['triggering_element']['#name'],'Hello from the fetchit7_param_form_force_triggering_element function. element name:');
+		$element_name_components = array();
+		$element_name_components = explode('_',$form_state['triggering_element']['#name']);
+		debug($element_name_components,'Hello from the fetchit7_param_form_force_triggering_element function. element name components:');
+		variable_set($form_state['triggering_element']['#name'],TRUE);
+		//save the existing state of all the form elements
+		$param_count = $form['param_count']['#value'];
+		for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
+			$element_name = $element_name_components[0].'_'.$element_name_components[1].'_'.$element_name_components[2].'_'.$element_name_components[3].'_'.$param_ndx;
+			variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
+		}
+		//$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
+	} else {
+		//debug($form_state['triggering_element']['#name'],'Hello from the fetchit7_param_form_force_triggering_element function. element name:');
+	}
+	/*
 	if (isset($form_state['input']['all'])) {
 		$string=$form_state['input']['all'];
 		$form_state['triggering_element'] = $form['all'];
@@ -1257,22 +1319,22 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 			debug($string,'Hello from the fetchit7_param_form_force_triggering_element function. From here it appears nothing was pressed (yet?) but triggering element is:');
 		}
 	}
+	*/
 	return $form;
 }
 /**
  * Process form validation
  */
 function fetchit7_param_all_validate($form, &$form_state) {
-	$nid = $form['nid']['#value'];
-	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,'Hello from the parameter all validate function. From here it appears the param_count is:');
-	drupal_set_message(t('Successfully submitted changes.'), 'status');
+	debug($form_state['triggering_element']['#name'],'Hello from the parameter all validate function. From here the triggering element is:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter all validate function. From here the triggering element is:');
+	drupal_set_message(t('Successfully validated all.'), 'status');
 }
 
 function fetchit7_param_none_validate($form, &$form_state) {
-	$nid = $form['nid']['#value'];
-	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,'Hello from the parameter none validate function. From here it appears the param_count is:');
+	debug($form_state['triggering_element']['#name'],'Hello from the parameter none validate function. From here the triggering element is:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter none validate function. From here the triggering element is:');
+	drupal_set_message(t('Successfully validated none.'), 'status');
 }
 
 function fetchit7_param_form_validate($form, &$form_state) {
@@ -1289,16 +1351,14 @@ function fetchit7_param_form_validate($form, &$form_state) {
 }
 
 function fetchit7_param_all_submit($form, &$form_state) {
-	$nid = $form['nid']['#value'];
-	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,'Hello from the parameter all submit function. From here it appears the param_count is:');
+	debug($form_state['triggering_element']['#name'],'Hello from the parameter all submit function. From here the triggering element is:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter all submit function. From here the triggering element is:');
 	drupal_set_message(t('Successfully selected all.'), 'status');
 }
 
 function fetchit7_param_none_submit($form, &$form_state) {
-	$nid = $form['nid']['#value'];
-	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,'Hello from the parameter none submit function. From here it appears the param_count is:');
+	debug($form_state['triggering_element']['#name'],'Hello from the parameter none submit function. From here the triggering element is:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter none submit function. From here the triggering element is:');
 	drupal_set_message(t('Successfully selected none.'), 'status');
 }
 
@@ -1456,9 +1516,13 @@ function theme_fetchit7_param_form($variables) {
         if ($p_ndx < $param_count) {
           $element_name = fetchit_make_element_name($nid, 0, $p_ndx);
           if ($submit_button_flag) {
-            $row[] = drupal_render($form['elements'][$element_name]).
-            			drupal_render($form['all']).
-            			drupal_render($form['none']);
+          	if (isset($form['elements'][$element_name.'_allbtn']) && isset($form['elements'][$element_name.'_nonebtn'])) {
+	            $row[] = drupal_render($form['elements'][$element_name]).
+    	        			drupal_render($form['elements'][$element_name.'_allbtn']).
+        	    			drupal_render($form['elements'][$element_name.'_nonebtn']);
+          	} else {
+          		$row[] = drupal_render($form['elements'][$element_name]);
+          	}    
           } else {
           	$row[] = drupal_render($form['elements'][$element_name]);
           }
@@ -1488,8 +1552,10 @@ function theme_fetchit7_param_form($variables) {
 	  $element_name = fetchit_make_element_name($nid, 0, $p_ndx);
 	  if ($submit_button_flag) {
 	  	$output .= drupal_render($form['elements'][$element_name]);
-        $output .= drupal_render($form['all']);
-        $output .= drupal_render($form['none']);
+       	if (isset($form['elements'][$element_name.'_allbtn']) && isset($form['elements'][$element_name.'_nonebtn'])) {
+	  		$output .= drupal_render($form['elements'][$element_name.'_allbtn']);
+        	$output .= drupal_render($form['elements'][$element_name.'_nonebtn']);
+       	}
 	  } else {
 	  	$output .= drupal_render($form['elements'][$element_name]);
 	  }

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -792,27 +792,29 @@ function fetchit7_param_form($form, &$form_state) {
     return $form;
   }
   // optional
+  //should return an array
   $param_titles = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_title', 'values'));
   //should return an array
   $param_descriptions = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_desc', 'values'));
-  //should return an array
   // i equivocate on this, but for now is optional - there is a default control type that is picked based on the output field type
+  //should return an array
   $param_types = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_type', 'values'));
-  //should return an array
   // weights are integers, but leave these input values as strings until later
-  $param_weights = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_weight', 'values'));
   //should return an array
+  $param_weights = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_weight', 'values'));
   //debug($param_weights,'$param_weights');
   // boolean, but leave these input values as strings until later, also can deal with default values then
+  //should return an array
   $param_enabled = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_enabled', 'values'));
-  //should return an array
   // boolean, but leave these input values as strings until later, also can deal with default values then
+  //should return an array
   $param_required = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_required', 'values'));
-  //should return an array
-  // optional
-  $param_str = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_parstr', 'values'));
-  //should return an array
 
+  // optional
+  //should return an array
+  $param_str = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_parstr', 'values'));
+
+  //should return an array
   $param_list_tbl = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_list_tbl', 'values'));
   //should return an array
   $param_list_key = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_list_key', 'values'));
@@ -821,15 +823,16 @@ function fetchit7_param_form($form, &$form_state) {
   //should return an array
   $param_list_uid = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_list_uid', 'values'));
   //should return an array
+  // note that the default strings in this array might have a "special" initial char, which will be handled later
   $param_list_def = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_list_def', 'values'));
+  
   //should return an array
-
+  // note that the database table names in this array might have a "special" initial char, which will be handled later
   $param_data_tbl = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_data_tbl', 'values'));
   //should return an array
   $param_data_key = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_data_key', 'values'));
   //should return an array
   $param_data_uid = array_map('trim', fetchit7_content_field_fetcher($nid, 'fetchit7_field_par_fld_data_uid', 'values'));
-  //should return an array
 
   //use the above arrays to contruct the $user_field_data array allowing the use of the fetchit2 code AMAP
   // note that param names DEFINES the count of the fields
@@ -963,7 +966,6 @@ function fetchit7_param_form($form, &$form_state) {
     //   - means put all and none buttons above, 
     //   * and + means put all and none buttons below
     // also strip the special character from the default value if it is there (- * +)
-    //   and the default value after stripping becomes the integer threshold for adding the buttons (>= means put the buttons)
     if ($field_index < count($param_list_def)) {
       if (strlen($param_list_def[$field_index])) {
         $user_field_data[$field_index][F_DR_FIELD_DEFAULT_CHAR_STR] = fetchit7_get_special_char_default($param_list_def[$field_index]);
@@ -978,16 +980,82 @@ function fetchit7_param_form($form, &$form_state) {
     }
 
     //$param_data_tbl F_DR_FIELD_DATA_TBL_STR
-    // this is required
+    // this is a required value
     // adding something new here - if the first char is a special character:
     //   - means default selection is none
     //   * means default selection is previous selection
     //   + means default selection is all
     // also strip the special character from the table name if it is there (- * +)
+    //   only doing this because it could be confusing to the fetchit user to have special characters
+    //   on selectable tables but not parameters - so support it on both, even though it is not
+    //   necessary on parameters
     if ($field_index < count($param_data_tbl)) {
       if (strlen($param_data_tbl[$field_index])) {
         $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR] = fetchit7_get_special_char_default($param_data_tbl[$field_index]);
         $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_STR] = fetchit7_strip_special_char_default($param_data_tbl[$field_index]);
+        if (strlen($user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR])) {
+        	// then set the default if it isn't set already
+        	if ($user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR]=='') {
+        		switch ($user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR]) {
+        			case '-':
+        				// unfortunately have to know the param type to know the appropriate default
+        				switch ($user_field_data[$field_index][F_DR_FIELD_INPUT_TYPE_STR]) {
+        					case F_DR_CONTROL_DROPDOWN_SINGLE:
+        					case F_DR_CONTROL_RADIOBTN:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_FIRST;
+        						break;
+        					case F_DR_CONTROL_CHECKBOXES:
+        					case F_DR_CONTROL_DROPDOWN_MULTI:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_NONE;
+        						break;
+        					case F_DR_CONTROL_CHECKBOX:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_FALSE;
+        						break;
+        					default:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
+        				}
+        				break;
+        			case '*':
+        				// unfortunately have to know the param type to know the appropriate default
+        				switch ($user_field_data[$field_index][F_DR_FIELD_INPUT_TYPE_STR]) {
+        					case F_DR_CONTROL_DROPDOWN_SINGLE:
+        					case F_DR_CONTROL_RADIOBTN:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_PREVIOUS;
+        						break;
+        					case F_DR_CONTROL_CHECKBOXES:
+        					case F_DR_CONTROL_DROPDOWN_MULTI:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_PREVIOUS;
+        						break;
+        					case F_DR_CONTROL_CHECKBOX:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_PREVIOUS;
+        						break;
+        					default:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
+        				}
+        				break;
+        			case '+':
+        		        // unfortunately have to know the param type to know the appropriate default
+        				switch ($user_field_data[$field_index][F_DR_FIELD_INPUT_TYPE_STR]) {
+        					case F_DR_CONTROL_DROPDOWN_SINGLE:
+        					case F_DR_CONTROL_RADIOBTN:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_FIRST;
+        						break;
+        					case F_DR_CONTROL_CHECKBOXES:
+        					case F_DR_CONTROL_DROPDOWN_MULTI:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_ALL;
+        						break;
+        					case F_DR_CONTROL_CHECKBOX:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = FETCHIT7_FIELD_DEFAULT_TRUE;
+        						break;
+        					default:
+        						$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
+        				}
+        				break;
+        			default:
+        				$user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
+        		}
+        	}
+        }
       }
       else {
         // can't have a default here, too many complications
@@ -4487,7 +4555,7 @@ function fetchit_get_selectmultiple_element($user_field_data, $user_field_ndx, $
 				foreach ($db_values as $db_value) {
 					if (in_array($db_value, $options_keys)) {
 						$found_values[] = $db_value;
-		    	}
+					}
 				}
 				$defaults = $found_values;
 			} else {
@@ -4496,42 +4564,41 @@ function fetchit_get_selectmultiple_element($user_field_data, $user_field_ndx, $
 		} else {
 	    $defaults = array();
 		}
-  } else {
-    $defaults = array();
+	} else {
+    	$defaults = array();
 	}
 	
-  // then set up the defaults based on the string they typed into the defaults attribute box
-  if (strlen($entered = trim($user_field_data[$user_field_ndx][F_DR_FIELD_DEFAULT_STR]))) {
-    switch ($entered) {
-	    case FETCHIT7_FIELD_DEFAULT_PREVIOUS:
-	      // over write defaults with the value they entered last time
-	      // already set
-	      break;
-	    case FETCHIT7_FIELD_DEFAULT_TRUE:
-		    $default = $options_keys[1];
+	// then set up the defaults based on the string they typed into the defaults attribute box
+	if (strlen($entered = trim($user_field_data[$user_field_ndx][F_DR_FIELD_DEFAULT_STR]))) {
+		switch ($entered) {
+			case FETCHIT7_FIELD_DEFAULT_PREVIOUS:
+				// over write defaults with the value they entered last time
+				// already set
 				break;
-	    case FETCHIT7_FIELD_DEFAULT_FALSE:
-		    $default = $options_keys[0];
+			case FETCHIT7_FIELD_DEFAULT_TRUE:
+		    	$default = $options_keys[1];
 				break;
-	    case FETCHIT7_FIELD_DEFAULT_NONE:
-	    case FETCHIT7_FIELD_DEFAULT_BLANK:
-	      $defaults = array('');
-	      break;
-	    case FETCHIT7_FIELD_DEFAULT_FIRST:
-	      $defaults = array($options_keys[0]);
-	      break;
-	    case FETCHIT7_FIELD_DEFAULT_ALL:
-	      $defaults = $options_keys;
-	      break;
-	    default:
-	      $userdefaults = explode(',', $entered);
-	      if (count($userdefaults)) {
-	        $defaults = $userdefaults;
-	      }
-	      else {
-	        $defaults = array('');
-	      }
-	  }
+			case FETCHIT7_FIELD_DEFAULT_FALSE:
+				$default = $options_keys[0];
+				break;
+			case FETCHIT7_FIELD_DEFAULT_NONE:
+	    	case FETCHIT7_FIELD_DEFAULT_BLANK:
+	      		$defaults = array('');
+	      		break;
+	    	case FETCHIT7_FIELD_DEFAULT_FIRST:
+	      		$defaults = array($options_keys[0]);
+	      		break;
+	    	case FETCHIT7_FIELD_DEFAULT_ALL:
+				$defaults = $options_keys;
+			break;
+		default:
+			$userdefaults = explode(',', $entered);
+			if (count($userdefaults)) {
+				$defaults = $userdefaults;
+			} else {
+	        	$defaults = array('');
+	      	}
+	  	}
 	}
 
   if ($showtitles) {
@@ -5660,8 +5727,17 @@ function fetchit_booleantointeger($val) {
 }
 
 function fetchit7_get_control_list() {
-  return array(// add 1 to make array_search() easier.  subtract 1 later...
-  F_DR_CONTROL_TEXTBOX + 1 => FETCHIT7_CONTROLTYPE_NAME_TEXTBOX, F_DR_CONTROL_DATESEL + 1 => FETCHIT7_CONTROLTYPE_NAME_DATESEL, F_DR_CONTROL_DROPDOWN_SINGLE + 1 => FETCHIT7_CONTROLTYPE_NAME_DROPDOWN_SINGLE, F_DR_CONTROL_RADIOBTN + 1 => FETCHIT7_CONTROLTYPE_NAME_RADIOBTN, F_DR_CONTROL_CHECKBOXES + 1 => FETCHIT7_CONTROLTYPE_NAME_CHECKBOXES, F_DR_CONTROL_DROPDOWN_MULTI + 1 => FETCHIT7_CONTROLTYPE_NAME_DROPDOWN_MULTI, F_DR_CONTROL_CHECKBOX + 1 => FETCHIT7_CONTROLTYPE_NAME_CHECKBOX, F_DR_CONTROL_DATETIMESEL + 1 => FETCHIT7_CONTROLTYPE_NAME_DATETIMESEL, F_DR_CONTROL_POPUPDATE + 1 => FETCHIT7_CONTROLTYPE_NAME_POPUPDATE, );
+	return array(// add 1 to make array_search() easier.  subtract 1 later...
+		F_DR_CONTROL_TEXTBOX + 1 => FETCHIT7_CONTROLTYPE_NAME_TEXTBOX,
+		F_DR_CONTROL_DATESEL + 1 => FETCHIT7_CONTROLTYPE_NAME_DATESEL,
+		F_DR_CONTROL_DROPDOWN_SINGLE + 1 => FETCHIT7_CONTROLTYPE_NAME_DROPDOWN_SINGLE,
+		F_DR_CONTROL_RADIOBTN + 1 => FETCHIT7_CONTROLTYPE_NAME_RADIOBTN,
+		F_DR_CONTROL_CHECKBOXES + 1 => FETCHIT7_CONTROLTYPE_NAME_CHECKBOXES,
+		F_DR_CONTROL_DROPDOWN_MULTI + 1 => FETCHIT7_CONTROLTYPE_NAME_DROPDOWN_MULTI,
+		F_DR_CONTROL_CHECKBOX + 1 => FETCHIT7_CONTROLTYPE_NAME_CHECKBOX,
+		F_DR_CONTROL_DATETIMESEL + 1 => FETCHIT7_CONTROLTYPE_NAME_DATETIMESEL,
+		F_DR_CONTROL_POPUPDATE + 1 => FETCHIT7_CONTROLTYPE_NAME_POPUPDATE,
+	);
 }
 
 function fetchit7_get_control_list_string() {

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1185,9 +1185,10 @@ function fetchit7_param_form($form, &$form_state) {
 	        $form['elements'][$element_name.'_allbtn'] = array(
 	        		'#type' => 'submit',
 	        		'#name' => $element_name.'_allbtn',
-	        		'#validate' => array(
-	        				'fetchit7_param_all_validate'
-	        		),
+	        		//'#validate' => array(
+	        		//		'fetchit7_param_all_validate'
+	        		//),
+	        		'#limit_validation_errors' => array(),
 	        		'#submit' => array(
 	        				'fetchit7_param_all_submit'
 	        		),
@@ -1197,9 +1198,10 @@ function fetchit7_param_form($form, &$form_state) {
 	        $form['elements'][$element_name.'_nonebtn'] = array(
 	        		'#type' => 'submit',
 	        		'#name' => $element_name.'_nonebtn',
-	        		'#validate' => array(
-	        				'fetchit7_param_none_validate'
-	        		),
+	        		'#limit_validation_errors' => array(),
+	        		//'#validate' => array(
+	        		//		'fetchit7_param_none_validate'
+	        		//),
 	        		'#submit' => array(
 	        				'fetchit7_param_none_submit'
 	        		),
@@ -1369,12 +1371,14 @@ function fetchit7_param_all_validate($form, &$form_state) {
 	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_validate function: triggering element:');
 	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_validate function. triggering element variable value:');
 	drupal_set_message(t('Successfully validated all button.'), 'status');
+	return;
 }
 
 function fetchit7_param_none_validate($form, &$form_state) {
 	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_validate function: triggering element:');
 	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_validate function: triggering element variable value:');
 	drupal_set_message(t('Successfully validated none button.'), 'status');
+	return;
 }
 
 function fetchit7_param_form_validate($form, &$form_state) {

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1188,32 +1188,39 @@ function fetchit7_param_form($form, &$form_state) {
             }
             // only need to make these if it is this type of control
             // be sure to check isset in theme function, though
-	        $form['elements'][$element_name.'_allbtn'] = array(
-	        		'#type' => 'submit',
-	        		'#name' => $element_name.'_allbtn',
-	        		//'#validate' => array(
-	        		//		'fetchit7_param_all_validate'
-	        		//),
-	        		'#limit_validation_errors' => array(),
-	        		'#submit' => array(
-	        				'fetchit7_param_all_submit'
-	        		),
-	        		'#buttontype' => 'button',
-	        		'#value' => t('All'),
-	        );
-	        $form['elements'][$element_name.'_nonebtn'] = array(
-	        		'#type' => 'submit',
-	        		'#name' => $element_name.'_nonebtn',
-	        		'#limit_validation_errors' => array(),
-	        		//'#validate' => array(
-	        		//		'fetchit7_param_none_validate'
-	        		//),
-	        		'#submit' => array(
-	        				'fetchit7_param_none_submit'
-	        		),
-	        		'#buttontype' => 'button',
-	        		'#value' => t('None'),
-	        );
+            switch ($user_field_data[$i][FETCHIT7_ALLNONE_SPECIAL_CHAR_STR]) {
+            	case '-':
+            	case '*':
+            	case '+':
+			        $form['elements'][$element_name.'_allbtn'] = array(
+			        		'#type' => 'submit',
+			        		'#name' => $element_name.'_allbtn',
+			        		//'#validate' => array(
+			        		//		'fetchit7_param_all_validate'
+			        		//),
+			        		'#limit_validation_errors' => array(),
+			        		'#submit' => array(
+			        				'fetchit7_param_all_submit'
+			        		),
+			        		'#buttontype' => 'button',
+			        		'#value' => t('All'),
+			        );
+			        $form['elements'][$element_name.'_nonebtn'] = array(
+			        		'#type' => 'submit',
+			        		'#name' => $element_name.'_nonebtn',
+			        		'#limit_validation_errors' => array(),
+			        		//'#validate' => array(
+			        		//		'fetchit7_param_none_validate'
+			        		//),
+			        		'#submit' => array(
+			        				'fetchit7_param_none_submit'
+			        		),
+			        		'#buttontype' => 'button',
+			        		'#value' => t('None'),
+			        );
+            		break;
+            	default:
+            }
             break;
           case F_DR_CONTROL_DROPDOWN_SINGLE:
           case F_DR_CONTROL_RADIOBTN:
@@ -1562,8 +1569,7 @@ function fetchit7_param_form_submit($form, &$form_state) {
       $form_state['redirect'] = $redirect;
     }
   }
-
-  drupal_set_message(t('Successfully submitted changes at '.microtime(true)), 'status');
+  drupal_set_message(t('Successfully submitted changes.'), 'status');
 }
 
 function theme_fetchit7_param_form($variables) {
@@ -1585,6 +1591,7 @@ function theme_fetchit7_param_form($variables) {
   if ($table_row_count) {
     //figure out the table structure
     $param_count = $form['param_count']['#value'];
+    //debug($param_count,'$param_count');
     $table_column_count = intval(($param_count - 1) / $table_row_count) + 1;
     $table_headers = $form['table_headers']['#value'];
     $table_headers_count = count($table_headers);
@@ -1599,25 +1606,41 @@ function theme_fetchit7_param_form($variables) {
     }
     $rows = array();
     for ($row_ndx = 0; $row_ndx < $table_row_count; $row_ndx++) {
+      //debug($row_ndx,'$row_ndx');
       $row = array();
       for ($col_ndx = 0; $col_ndx < $table_column_count; $col_ndx++) {
-        // numbering goes down the columns first
+        //debug($col_ndx,'$col_ndx');
+      	// numbering goes down the columns first
         $p_ndx = $row_ndx + $col_ndx * $table_row_count;
+        //debug($p_ndx,'$p_ndx');
         if ($p_ndx < $param_count) {
           $element_name = fetchit_make_element_name($nid, 0, $p_ndx);
+          //debug($element_name,'$element_name');
           if ($submit_button_flag) {
           	if (isset($form['elements'][$element_name.'_allbtn']) && isset($form['elements'][$element_name.'_nonebtn'])) {
-	            $row[] = drupal_render($form['elements'][$element_name]).
-    	        			drupal_render($form['elements'][$element_name.'_allbtn']).
-        	    			drupal_render($form['elements'][$element_name.'_nonebtn']);
+                //debug($form['param_allnone'][$p_ndx]['#value'],'$form[param_allnone][$p_ndx][#value]');
+          		switch ($form['param_allnone'][$p_ndx]['#value']) {
+	          		case '-':
+		          		$row[] = drupal_render($form['elements'][$element_name.'_allbtn']).
+		        	    			drupal_render($form['elements'][$element_name.'_nonebtn']).
+		        	    			drupal_render($form['elements'][$element_name]);
+	          			break;
+	          		case '+':
+	          		case '*':
+		          		$row[] = drupal_render($form['elements'][$element_name]).
+		    	        			drupal_render($form['elements'][$element_name.'_allbtn']).
+		        	    			drupal_render($form['elements'][$element_name.'_nonebtn']);
+	          			break;
+	          		default:
+		          		$row[] = drupal_render($form['elements'][$element_name]);
+          	    }
           	} else {
           		$row[] = drupal_render($form['elements'][$element_name]);
           	}    
           } else {
           	$row[] = drupal_render($form['elements'][$element_name]);
           }
-        }
-        else {
+        } else {
           $sillyform[$p_ndx] = array(
           		'#type' => 'item',
           		'#title' => 'Empty Cell',
@@ -1635,16 +1658,29 @@ function theme_fetchit7_param_form($variables) {
     		'#weight' => $table_weight,
     		'#empty' => "Empty table.", );
     $output .= drupal_render($form['table']);
-  }
-  else {
+  } else {
     $param_count = $form['param_count']['#value'];
 	for ($p_ndx=0; $p_ndx < $param_count; $p_ndx++) {
 	  $element_name = fetchit_make_element_name($nid, 0, $p_ndx);
 	  if ($submit_button_flag) {
-	  	$output .= drupal_render($form['elements'][$element_name]);
        	if (isset($form['elements'][$element_name.'_allbtn']) && isset($form['elements'][$element_name.'_nonebtn'])) {
-	  		$output .= drupal_render($form['elements'][$element_name.'_allbtn']);
-        	$output .= drupal_render($form['elements'][$element_name.'_nonebtn']);
+       		switch ($form['param_allnone'][$p_ndx]['#value']) {
+       			case '-':
+	  				$output .= drupal_render($form['elements'][$element_name.'_allbtn']);
+	  				$output .= drupal_render($form['elements'][$element_name.'_nonebtn']);
+	  				$output .= drupal_render($form['elements'][$element_name]);
+       				break;
+       			case '+':
+       			case '*':
+       				$output .= drupal_render($form['elements'][$element_name]);
+       				$output .= drupal_render($form['elements'][$element_name.'_allbtn']);
+       				$output .= drupal_render($form['elements'][$element_name.'_nonebtn']);
+       				break;
+       			default:
+       				$output .= drupal_render($form['elements'][$element_name]);
+       		}
+       	} else {
+       		$output .= drupal_render($form['elements'][$element_name]);
        	}
 	  } else {
 	  	$output .= drupal_render($form['elements'][$element_name]);
@@ -1652,7 +1688,7 @@ function theme_fetchit7_param_form($variables) {
 	}
   }
   $output .= '</div>';
-  $submit_button_flag = $form['submit_button_flag']['#value'];
+  //$submit_button_flag = $form['submit_button_flag']['#value'];
   if ($submit_button_flag) {
     $output .= '<div class="' . $form_id . '_submit">';
     $output .= drupal_render($form['actions']['submit']);

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -90,6 +90,24 @@ function fetchit7_table_form($form, &$form_state) {
 
   // get table selection table - this is required for the copy selection types
   $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
+  $table_selection_default_flag = '-';
+  debug($table_selection_table,'before $table_selection_table');
+  debug($table_selection_default_flag,'before $table_selection_default_flag');
+  $table_selection_default_flag = '-';
+  if (strlen($table_selection_table)) {
+    switch ($table_selection_table[0]) {
+      case '-':
+      case '*':
+      case '+':
+        $table_selection_default_flag = $table_selection_table[0];
+        $table_selection_table = substr($table_selection_table, 1);
+        break;
+      default:
+        $table_selection_default_flag = '-';
+    }
+  }
+  debug($table_selection_table,'after $table_selection_table');
+  debug($table_selection_default_flag,'after $table_selection_default_flag');
   $form['record_select_table'] = array('#type' => 'value', '#value' => $table_selection_table);
   if (in_array($table_selection_type, array('copy_single', 'copy_multiple'))) {
     if (!strlen($table_selection_table)) {
@@ -195,7 +213,6 @@ function fetchit7_table_form($form, &$form_state) {
   // skip implementing this for now ... until after testing is done
   //$existing_selections = fetchit_get_existing_selection_nid($db_handle,$db_type,$nid);
   //$existing_selections = fetchit_get_existing_selection_nid($db_handle,$db_type,$nid);
-
   // loop through the fields and determine if they are either a source data key field or a drupal user id field
   // these are not displayed in the table or tableselect element
   // the key field values will become the options[] array keys used in record selection,
@@ -219,12 +236,26 @@ function fetchit7_table_form($form, &$form_state) {
   }
 	//debug($uid_field_ndx,'$uid_field_ndx');
 	//debug($key_field_ndx,'$key_field_ndx');
+  // create the data for no selection
+  $none_selection = null;
+  $none_selections = array();
+  // create the data for previous selection
+  $previous_selection = fetchit_get_existing_selection_single($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field);
+  $selections = fetchit_get_existing_selection_multiple($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field);
+  $previous_selections = array();
+  foreach ($selections as $selection) {
+     $previous_selections[$selection] = TRUE; 
+  }
+  // initialize the data for all and first selection
+  $all_selections = array();
+  $first_selection = null;
+  $first_selections = array();
   // create the render arrays for each case
   switch ($table_selection_type) {
     case 'copy_single':
-    // single row selection and key field copy via radio buttons
+      // single row selection and key field copy via radio buttons
     case 'copy_multiple':
-    // multiple row selection and key field copy via check boxes
+      // multiple row selection and key field copy via check boxes
     case 'delete_multiple':
       // multiple row selection and record deletion via check boxes
       // create the HTML tableselect header and options
@@ -243,12 +274,14 @@ function fetchit7_table_form($form, &$form_state) {
             if ($field_ndx == ($key_field_ndx - 1)) {
               // use this as the key for the options array
               $options_key = $db_value;
-              if ($row_ndx == 0) {
-                $default_value = $db_value;
-              }
+              // its the index field
+              $all_selections[$db_value] = TRUE;
             }
             else {
               if ($row_ndx == 0) {
+                // its the first row
+                $first_selection = $db_value;
+                $first_selections[$db_value] = TRUE;
                 if ($column_count < $table_headers_count) {
                   $header['column' . $column_count] = $table_headers[$column_count];
                 }
@@ -269,14 +302,62 @@ function fetchit7_table_form($form, &$form_state) {
       if ($table_selection_type == 'copy_single') {
         $multiple_flag = FALSE;
         $selectall_flag = FALSE;
-        $default_value = 0;
       }
       else {
         $multiple_flag = TRUE;
         $selectall_flag = TRUE;
-        $default_value = array();
-        // reset to nothing selected
       }
+      // set the default based on the type and the flag
+      switch ($table_selection_type) {
+        case 'copy_single':
+          switch ($table_selection_default_flag) {
+            case '-':
+              $default_value = $first_selection;
+              break;
+            case '*':
+              $default_value = $previous_selection;
+              break;
+            case '+':
+              $default_value = $first_selection;
+              break;
+            default:
+              $default_value = $first_selection;
+          }
+          break;
+        case 'copy_multiple':
+          switch ($table_selection_default_flag) {
+            case '-':
+              $default_value = $none_selections;
+              break;
+            case '*':
+              $default_value = $previous_selections;
+              break;
+            case '+':
+              $default_value = $all_selections;
+              break;
+            default:
+              $default_value = $none_selections;
+          }
+          break;
+        case 'delete_multiple':
+          switch ($table_selection_default_flag) {
+            case '-':
+              $default_value = $none_selections;
+              break;
+            case '*':
+              $default_value = $none_selections;
+              break;
+            case '+':
+              $default_value = $all_selections;
+              break;
+            default:
+              $default_value = $none_selections;
+          }
+          break;
+        default:
+          $default_value = null;
+      } 
+      debug($default_value,'$default_value');
       // create the HTML tableselect render array with a single select option
       $form['table'] = array(
       	'#type' => 'tableselect',
@@ -2870,6 +2951,16 @@ function fetchit_get_existing_selection_nid($db_handle, $db_type, $nid) {
           case 'copy_single':
             // radio button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
+            if (strlen($table_selection_table)) {
+              switch ($table_selection_table[0]) {
+                case '-':
+                case '*':
+                case '+':
+                  $table_selection_table = substr($table_selection_table, 1);
+                  break;
+                default:
+              }
+            }
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_get_existing_selection_single($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field);
@@ -2879,6 +2970,16 @@ function fetchit_get_existing_selection_nid($db_handle, $db_type, $nid) {
           case 'copy_multiple':
             // check boxes button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
+            if (strlen($table_selection_table)) {
+              switch ($table_selection_table[0]) {
+                case '-':
+                case '*':
+                case '+':
+                  $table_selection_table = substr($table_selection_table, 1);
+                  break;
+                default:
+              }
+            }
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_get_existing_selection_multiple($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field);
@@ -2906,6 +3007,16 @@ function fetchit_set_existing_selection_nid($db_handle, $db_type, $nid, $val) {
           case 'copy_single':
             // radio button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
+            if (strlen($table_selection_table)) {
+              switch ($table_selection_table[0]) {
+                case '-':
+                case '*':
+                case '+':
+                  $table_selection_table = substr($table_selection_table, 1);
+                  break;
+                default:
+              }
+            }
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_set_existing_selection_single($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field, $val);
@@ -2915,6 +3026,16 @@ function fetchit_set_existing_selection_nid($db_handle, $db_type, $nid, $val) {
           case 'copy_multiple':
             // check boxes button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
+            if (strlen($table_selection_table)) {
+              switch ($table_selection_table[0]) {
+                case '-':
+                case '*':
+                case '+':
+                  $table_selection_table = substr($table_selection_table, 1);
+                  break;
+                default:
+              }
+            }
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_set_existing_selection_multiple($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field, $val);

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -965,11 +965,11 @@ function fetchit7_param_form($form, &$form_state) {
     // adding something new here - if the first char is a special character:
     //   - means put all and none buttons above, 
     //   * and + means put all and none buttons below
-    // also strip the special character from the default value if it is there (- * +)
+    // also strip the special allnone button character from the default value if it is there (- * +)
     if ($field_index < count($param_list_def)) {
       if (strlen($param_list_def[$field_index])) {
-        $user_field_data[$field_index][F_DR_FIELD_DEFAULT_CHAR_STR] = fetchit7_get_special_char_default($param_list_def[$field_index]);
-        $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = fetchit7_strip_special_char_default($param_list_def[$field_index]);
+        $user_field_data[$field_index][FETCHIT7_ALLNONE_SPECIAL_CHAR_STR] = fetchit7_get_special_char_allnone($param_list_def[$field_index]);
+        $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = fetchit7_strip_special_char_allnone($param_list_def[$field_index]);
       }
       else {
         $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
@@ -991,12 +991,13 @@ function fetchit7_param_form($form, &$form_state) {
     //   necessary on parameters
     if ($field_index < count($param_data_tbl)) {
       if (strlen($param_data_tbl[$field_index])) {
-        $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR] = fetchit7_get_special_char_default($param_data_tbl[$field_index]);
+        $user_field_data[$field_index][FETCHIT7_DEFAULT_SPECIAL_CHAR_STR] = fetchit7_get_special_char_default($param_data_tbl[$field_index]);
         $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_STR] = fetchit7_strip_special_char_default($param_data_tbl[$field_index]);
-        if (strlen($user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR])) {
-        	// then set the default if it isn't set already
+        // if we have a special character on the table name
+        if (strlen($user_field_data[$field_index][FETCHIT7_DEFAULT_SPECIAL_CHAR_STR])) {
+        	// then set the default via the param default field if it isn't set already
         	if ($user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR]=='') {
-        		switch ($user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR]) {
+        		switch ($user_field_data[$field_index][FETCHIT7_DEFAULT_SPECIAL_CHAR_STR]) {
         			case '-':
         				// unfortunately have to know the param type to know the appropriate default
         				switch ($user_field_data[$field_index][F_DR_FIELD_INPUT_TYPE_STR]) {
@@ -5768,6 +5769,21 @@ function fetchit7_strip_special_char_default($val) {
   return $newval;
 }
 
+function fetchit7_strip_special_char_allnone($val) {
+	$newval=$val;
+	if (strlen($val)) {
+		switch ($val[0]) {
+			case '-':
+			case '*':
+			case '+':
+				$newval = substr($val, 1);
+				break;
+			default:
+		}
+	}
+	return $newval;
+}
+
 function fetchit7_get_special_char_default($val) {
   $special_char = '';
   if (strlen($val)) {
@@ -5781,4 +5797,19 @@ function fetchit7_get_special_char_default($val) {
     }
   }
   return $special_char;
+}
+
+function fetchit7_get_special_char_allnone($val) {
+	$special_char = '';
+	if (strlen($val)) {
+		switch ($val[0]) {
+			case '-':
+			case '*':
+			case '+':
+				$special_char = $val[0];
+				break;
+			default:
+		}
+	}
+	return $special_char;
 }

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -676,7 +676,7 @@ function fetchit7_param_form($form, &$form_state) {
 
   // get nid embedded into original form_id; format fetchit7_param_form_X### - nid starts at character 21
   $form_id = $form_state['build_info']['form_id'];
-  debug($form_id, microtime(true).' fetchit7_param_form: $form_id:');
+  //debug($form_id, microtime(true).' fetchit7_param_form: $form_id:');
   // to get here, this is definitely set
   //debug($form_state['build_info']);
   $nid = (int) substr($form_id, 21);
@@ -1157,7 +1157,7 @@ function fetchit7_param_form($form, &$form_state) {
           case F_DR_CONTROL_DROPDOWN_MULTI:
           	// first get the previously saved state...
             $db_value = fetchit_get_existing_selection_multiple($db_handle, $db_type, $data_tbl, $data_ndx, $data_uid);
-			debug($db_value,microtime(true).' creating form element '.$element_name.'. Default value set to');
+			//debug($db_value,microtime(true).' creating form element '.$element_name.'. Default value set to');
             // next, check to see if there is an "interim state" to reset the control too
 	        //   (this happens when the user presses a select All or select None button)
 	        //   see if there is a stored variable with the name element_name_value
@@ -1170,7 +1170,7 @@ function fetchit7_param_form($form, &$form_state) {
 				//    is the previously selected state
         		$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_PREVIOUS;
 				$db_value = variable_get($element_name.'_value','');
-			    debug($db_value,microtime(true).' creating form element '.$element_name.'. RESETTING default value to');
+			    //debug($db_value,microtime(true).' creating form element '.$element_name.'. RESETTING default value to');
 				//and then finally erase the interim state flag...
 				variable_set($element_name.'_set',FALSE);
 			}
@@ -1224,7 +1224,7 @@ function fetchit7_param_form($form, &$form_state) {
           case F_DR_CONTROL_POPUPDATE:
             $db_value = fetchit_get_existing_selection_single($db_handle, $db_type, $data_tbl, $data_ndx, $data_uid);
 
-            debug($db_value,microtime(true).' creating form element '.$element_name.'. Default value set to');
+            //debug($db_value,microtime(true).' creating form element '.$element_name.'. Default value set to');
             // next, check to see if there is an "interim state" to reset the control too
             //   (this happens when the user presses a select All or select None button)
             //   see if there is a stored variable with the name element_name_value
@@ -1237,7 +1237,7 @@ function fetchit7_param_form($form, &$form_state) {
             	//    is the previously selected state
             	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_PREVIOUS;
             	$db_value = variable_get($element_name.'_value','');
-            	debug($db_value,microtime(true).' creating form element '.$element_name.'. RESETTING default value to');
+            	//debug($db_value,microtime(true).' creating form element '.$element_name.'. RESETTING default value to');
             	//and then finally erase the interim state flag...
             	variable_set($element_name.'_set',FALSE);
             }
@@ -1354,20 +1354,20 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 	 */
 	if(isset($form_state['triggering_element'])) {
 		$triggering_element_name = $form_state['triggering_element']['#name'];
-		debug($triggering_element_name,microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
+		//debug($triggering_element_name,microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
 		// blow up the element name to get the info out of it
 		$triggering_element_name_components = array();
 		$triggering_element_name_components = explode('_',$triggering_element_name);
-		debug($triggering_element_name_components,microtime(true).' fetchit7_param_form_force_triggering_element: element name components:');
+		//debug($triggering_element_name_components,microtime(true).' fetchit7_param_form_force_triggering_element: element name components:');
 		if ($triggering_element_name_components[0]=="fetchit7") {
 			//save the existing state of ALL the form elements
 			$param_count = $form['param_count']['#value'];
 			for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
 				$element_name = $triggering_element_name_components[0].'_'.$triggering_element_name_components[1].'_'.$triggering_element_name_components[2].'_'.$triggering_element_name_components[3].'_'.$param_ndx;
-				debug($element_name,microtime(true).' fetchit7_param_form_element: element name:');
+				//debug($element_name,microtime(true).' fetchit7_param_form_element: element name:');
 				variable_set($element_name.'_set',true);
 				variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
-				debug($form_state['values']['elements'][$element_name],microtime(true).' fetchit7_param_form_element: element value:');
+				//debug($form_state['values']['elements'][$element_name],microtime(true).' fetchit7_param_form_element: element value:');
 				// set them all to false, then set the triggering to true afterwards
 				// notice that $element_name (the value/list control) is the base of $triggering_element_name (the all or none button)
 				variable_set($element_name.'_allbtn',false);
@@ -1382,7 +1382,7 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 			$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 		}
 	} else {
-		debug('',microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is NOT set');
+		//debug('',microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is NOT set');
 	}
 	/*
 	if (isset($form_state['input']['all'])) {
@@ -1413,22 +1413,22 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
  * Process form validation
  */
 function fetchit7_param_all_validate($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_validate function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_validate function. triggering element variable value:');
-	drupal_set_message(t('Successfully validated all button.'), 'status');
+	//debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_validate function: triggering element:');
+	//debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_validate function. triggering element variable value:');
+	//drupal_set_message(t('Successfully validated all button.'), 'status');
 	return;
 }
 
 function fetchit7_param_none_validate($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_validate function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_validate function: triggering element variable value:');
-	drupal_set_message(t('Successfully validated none button.'), 'status');
+	//debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_validate function: triggering element:');
+	//debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_validate function: triggering element variable value:');
+	//drupal_set_message(t('Successfully validated none button.'), 'status');
 	return;
 }
 
 function fetchit7_param_form_validate($form, &$form_state) {
-	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,microtime(true).' fetchit7_param_form_validate function. $form[] param_count or $form_state[]:');
+	//$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
+	//debug($string,microtime(true).' fetchit7_param_form_validate function. $form[] param_count or $form_state[]:');
 	$nid = $form['nid']['#value'];
 	//$row_ndx = 0;
 	//$param_ndx = 0;
@@ -1440,15 +1440,15 @@ function fetchit7_param_form_validate($form, &$form_state) {
 }
 
 function fetchit7_param_all_submit($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_submit function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_submit function: triggering element variable value:');
-	drupal_set_message(t('Successfully submitted all button.'), 'status');
+	//debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_submit function: triggering element:');
+	//debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_submit function: triggering element variable value:');
+	//drupal_set_message(t('Successfully submitted all button.'), 'status');
 }
 
 function fetchit7_param_none_submit($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_submit function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_submit function: triggering element variable value:');
-	drupal_set_message(t('Successfully submitted none button.'), 'status');
+	//debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_submit function: triggering element:');
+	//debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_submit function: triggering element variable value:');
+	//drupal_set_message(t('Successfully submitted none button.'), 'status');
 }
 
 /**
@@ -1570,7 +1570,7 @@ function theme_fetchit7_param_form($variables) {
   $form = $variables['form'];
   $nid = $form['nid']['#value'];
   $form_id = $form['form_id']['#value'];
-  debug($form_id, microtime(true).' theme_fetchit7_param_form: $form_id:');
+  //debug($form_id, microtime(true).' theme_fetchit7_param_form: $form_id:');
   //the drupal way is to do all the non display related preprocessing in a theme preprocessor function
   // ... move it there later ...
   $table_row_count = $form['table_rows']['#value'];

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1073,26 +1073,92 @@ function fetchit7_param_form($form, &$form_state) {
     //  '#type' => 'actions',
     //);
     //debug($submit_weight,'$submit_weight');
-    $form['actions']['submit'] = array('#type' => 'submit', '#value' => $submit_label, '#weight' => $submit_weight, );
+    $form['actions']['submit'] = array(
+    		'#type' => 'submit',
+    		'#value' => $submit_label,
+    		'#weight' => $submit_weight, );
+    $form['all'] = array(
+    		'#type' => 'submit',
+    		'#value' => 'All',
+    		'#validate' => array('fetchit7_param_all_validate'),
+    		'#submit' => array('fetchit7_param_all_submit'),
+			'#weight' => $submit_weight-2, );
+    $form['none'] = array(
+    		'#type' => 'submit',
+    		'#value' => 'None',
+    		'#validate' => array('fetchit7_param_none_validate'),
+    		'#submit' => array('fetchit7_param_none_submit'),
+    		'#weight' => $submit_weight-1, );
   }
-
+  $form['#after_build'][] = 'fetchit7_param_form_force_triggering_element';
   return $form;
 }
 
+function fetchit7_param_form_force_triggering_element($form, &$form_state) {
+	if (isset($form_state['input']['all'])) {
+		$string=$form_state['input']['all'];
+		$form_state['triggering_element'] = $form['all'];
+	    debug($string,'Hello from the fetchit7_param_form_force_triggering_element function. From here it appears all was pressed:');
+	} elseif (isset($form_state['input']['none'])) {
+		$string=$form_state['input']['none'];
+		$form_state['triggering_element'] = $form['none'];
+	    debug($string,'Hello from the fetchit7_param_form_force_triggering_element function. From here it appears none was pressed:');
+	} elseif (isset($form_state['input']['actions']['submit'])) {
+		$string=$form_state['input']['actions']['submit'];
+		$form_state['triggering_element'] = $form['actions']['submit'];
+	    debug($string,'Hello from the fetchit7_param_form_force_triggering_element function. From here it appears submit was pressed:');
+	} else {
+		if (isset($form_state['triggering_element'])) {
+			$string=$form_state['triggering_element'];
+			debug($string,'Hello from the fetchit7_param_form_force_triggering_element function. From here it appears nothing was pressed (yet?) but triggering element is:');
+		} else {
+			$string=null;
+			debug($string,'Hello from the fetchit7_param_form_force_triggering_element function. From here it appears nothing was pressed (yet?) but triggering element is:');
+		}
+	}
+	return $form;
+}
 /**
  * Process form validation
  */
+function fetchit7_param_all_validate($form, &$form_state) {
+	$nid = $form['nid']['#value'];
+	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
+	debug($string,'Hello from the parameter all validate function. From here it appears the param_count is:');
+	drupal_set_message(t('Successfully submitted changes.'), 'status');
+}
+
+function fetchit7_param_none_validate($form, &$form_state) {
+	$nid = $form['nid']['#value'];
+	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
+	debug($string,'Hello from the parameter none validate function. From here it appears the param_count is:');
+}
+
 function fetchit7_param_form_validate($form, &$form_state) {
-  //$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-  //debug($string,'Hello from the all important parameter input form validate function. From here it appears the param_count is:');
-  $nid = $form['nid']['#value'];
-  //$row_ndx = 0;
-  //$param_ndx = 0;
-  //$element_name = fetchit_make_element_name($nid,$row_ndx,$param_ndx);
-  //debug($element_name,'$element_name');
-  //$control_type = $form['elements'][$element_name]['#type'];
-  //debug($control_type,'$control_type');
-  //debug($form_state['values']['elements'],'$form_state[values][elements]');
+	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
+	debug($string,'Hello from the all important parameter input form validate function. From here it appears the param_count is:');
+	$nid = $form['nid']['#value'];
+	//$row_ndx = 0;
+	//$param_ndx = 0;
+	//$element_name = fetchit_make_element_name($nid,$row_ndx,$param_ndx);
+	//debug($element_name,'$element_name');
+	//$control_type = $form['elements'][$element_name]['#type'];
+	//debug($control_type,'$control_type');
+	//debug($form_state['values']['elements'],'$form_state[values][elements]');
+}
+
+function fetchit7_param_all_submit($form, &$form_state) {
+	$nid = $form['nid']['#value'];
+	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
+	debug($string,'Hello from the parameter all submit function. From here it appears the param_count is:');
+	drupal_set_message(t('Successfully selected all.'), 'status');
+}
+
+function fetchit7_param_none_submit($form, &$form_state) {
+	$nid = $form['nid']['#value'];
+	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
+	debug($string,'Hello from the parameter none submit function. From here it appears the param_count is:');
+	drupal_set_message(t('Successfully selected none.'), 'status');
 }
 
 /**
@@ -1214,10 +1280,12 @@ function theme_fetchit7_param_form($variables) {
   $form = $variables['form'];
   $nid = $form['nid']['#value'];
   $form_id = $form['form_id']['#value'];
-  //the drupal way is to do all the non display related preprocessing in a theme preprocessor function ... move it there later ...
+  //the drupal way is to do all the non display related preprocessing in a theme preprocessor function
+  // ... move it there later ...
   $table_row_count = $form['table_rows']['#value'];
   //debug($table_row_count,'$table_row_count');
   $table_weight = $form['table_weight']['#value'];
+  $submit_button_flag = $form['submit_button_flag']['#value'];
   //debug($table_weight,'$table_weight');
   //figure out the formatting
   $output = '<div class="' . $form_id . '_params">';
@@ -1246,25 +1314,45 @@ function theme_fetchit7_param_form($variables) {
         $p_ndx = $row_ndx + $col_ndx * $table_row_count;
         if ($p_ndx < $param_count) {
           $element_name = fetchit_make_element_name($nid, 0, $p_ndx);
-          $row[] = drupal_render($form['elements'][$element_name]);
+          if ($submit_button_flag) {
+            $row[] = drupal_render($form['elements'][$element_name]).
+            			drupal_render($form['all']).
+            			drupal_render($form['none']);
+          } else {
+          	$row[] = drupal_render($form['elements'][$element_name]);
+          }
         }
         else {
-          $sillyform[$p_ndx] = array('#type' => 'item', '#title' => 'Empty Cell', '#markup' => "I am an empty cell.", );
+          $sillyform[$p_ndx] = array(
+          		'#type' => 'item',
+          		'#title' => 'Empty Cell',
+          		'#markup' => "I am an empty cell.", );
           $row[] = drupal_render($sillyform[$p_ndx]);
         }
       }
       $rows[] = $row;
     }
     //debug($table_weight,'$table_weight');
-    $form['table'] = array('#theme' => 'table', '#header' => $header, '#rows' => $rows, '#weight' => $table_weight, '#empty' => "Empty table.", );
+    $form['table'] = array(
+    		'#theme' => 'table',
+    		'#header' => $header,
+    		'#rows' => $rows,
+    		'#weight' => $table_weight,
+    		'#empty' => "Empty table.", );
     $output .= drupal_render($form['table']);
   }
   else {
     $param_count = $form['param_count']['#value'];
-		for ($p_ndx=0; $p_ndx < $param_count; $p_ndx++) {
-			$element_name = fetchit_make_element_name($nid, 0, $p_ndx);
-			$output .= drupal_render($form['elements'][$element_name]);
-		}
+	for ($p_ndx=0; $p_ndx < $param_count; $p_ndx++) {
+	  $element_name = fetchit_make_element_name($nid, 0, $p_ndx);
+	  if ($submit_button_flag) {
+	  	$output .= drupal_render($form['elements'][$element_name]);
+        $output .= drupal_render($form['all']);
+        $output .= drupal_render($form['none']);
+	  } else {
+	  	$output .= drupal_render($form['elements'][$element_name]);
+	  }
+	}
   }
   $output .= '</div>';
   $submit_button_flag = $form['submit_button_flag']['#value'];
@@ -2524,8 +2612,9 @@ function fetchit_get_db_handle($nid) {
         }
         // create the pg connection
         $db_string = "host=$db_host port=$db_port user=$db_login password=$db_password dbname=$db_name";
-				//debug($db_string,'$db_string');
+		//debug($db_string,'fetchit_get_db_handle '.$nid.' $db_string');
         $db_handle = pg_connect($db_string);
+		//debug($db_handle,'fetchit_get_db_handle '.$nid.' $db_handle');
         break;
       case FETCHIT7_DBTYPE_NAME_MYSQL:
         //'mysql':
@@ -2540,7 +2629,10 @@ function fetchit_get_db_handle($nid) {
 }
 
 function fetchit_run_query($db_type, $db_handle, $query) {
-  switch ($db_type) {
+	//debug($db_type,'fetchit_run_query $db_type');
+	//debug($db_handle,'fetchit_run_query $db_handle');
+	//debug($query,'fetchit_run_query $query');
+	switch ($db_type) {
     case FETCHIT7_DBTYPE_NAME_PGSQL:
       //'postgresql':
       $result = pg_query($db_handle, $query);

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -90,24 +90,15 @@ function fetchit7_table_form($form, &$form_state) {
 
   // get table selection table - this is required for the copy selection types
   $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
-  $table_selection_default_flag = '-';
-  debug($table_selection_table,'before $table_selection_table');
-  debug($table_selection_default_flag,'before $table_selection_default_flag');
-  $table_selection_default_flag = '-';
-  if (strlen($table_selection_table)) {
-    switch ($table_selection_table[0]) {
-      case '-':
-      case '*':
-      case '+':
-        $table_selection_default_flag = $table_selection_table[0];
-        $table_selection_table = substr($table_selection_table, 1);
-        break;
-      default:
-        $table_selection_default_flag = '-';
-    }
+  $table_selection_default_flag = fetchit7_get_special_char_default($table_selection_table);
+  $table_selection_table = fetchit7_strip_special_char_default($table_selection_table);
+  //debug($table_selection_table,'before $table_selection_table');
+  //debug($table_selection_default_flag,'before $table_selection_default_flag');
+  if($table_selection_default_flag == '') {
+    $table_selection_default_flag = '-';
   }
-  debug($table_selection_table,'after $table_selection_table');
-  debug($table_selection_default_flag,'after $table_selection_default_flag');
+  //debug($table_selection_table,'after $table_selection_table');
+  //debug($table_selection_default_flag,'after $table_selection_default_flag');
   $form['record_select_table'] = array('#type' => 'value', '#value' => $table_selection_table);
   if (in_array($table_selection_type, array('copy_single', 'copy_multiple'))) {
     if (!strlen($table_selection_table)) {
@@ -968,9 +959,15 @@ function fetchit7_param_form($form, &$form_state) {
     }
 
     //$param_list_def F_DR_FIELD_DEFAULT_STR
+    // adding something new here - if the first char is a special character:
+    //   - means put all and none buttons above, 
+    //   * and + means put all and none buttons below
+    // also strip the special character from the default value if it is there (- * +)
+    //   and the default value after stripping becomes the integer threshold for adding the buttons (>= means put the buttons)
     if ($field_index < count($param_list_def)) {
       if (strlen($param_list_def[$field_index])) {
-        $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = $param_list_def[$field_index];
+        $user_field_data[$field_index][F_DR_FIELD_DEFAULT_CHAR_STR] = fetchit7_get_special_char_default($param_list_def[$field_index]);
+        $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = fetchit7_strip_special_char_default($param_list_def[$field_index]);
       }
       else {
         $user_field_data[$field_index][F_DR_FIELD_DEFAULT_STR] = '';
@@ -982,9 +979,15 @@ function fetchit7_param_form($form, &$form_state) {
 
     //$param_data_tbl F_DR_FIELD_DATA_TBL_STR
     // this is required
+    // adding something new here - if the first char is a special character:
+    //   - means default selection is none
+    //   * means default selection is previous selection
+    //   + means default selection is all
+    // also strip the special character from the table name if it is there (- * +)
     if ($field_index < count($param_data_tbl)) {
       if (strlen($param_data_tbl[$field_index])) {
-        $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_STR] = $param_data_tbl[$field_index];
+        $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_CHAR_STR] = fetchit7_get_special_char_default($param_data_tbl[$field_index]);
+        $user_field_data[$field_index][F_DR_FIELD_DATA_TBL_STR] = fetchit7_strip_special_char_default($param_data_tbl[$field_index]);
       }
       else {
         // can't have a default here, too many complications
@@ -1158,18 +1161,6 @@ function fetchit7_param_form($form, &$form_state) {
     		'#type' => 'submit',
     		'#value' => $submit_label,
     		'#weight' => $submit_weight, );
-    $form['all'] = array(
-    		'#type' => 'submit',
-    		'#value' => 'All',
-    		'#validate' => array('fetchit7_param_all_validate'),
-    		'#submit' => array('fetchit7_param_all_submit'),
-			'#weight' => $submit_weight-2, );
-    $form['none'] = array(
-    		'#type' => 'submit',
-    		'#value' => 'None',
-    		'#validate' => array('fetchit7_param_none_validate'),
-    		'#submit' => array('fetchit7_param_none_submit'),
-    		'#weight' => $submit_weight-1, );
   }
   $form['#after_build'][] = 'fetchit7_param_form_force_triggering_element';
   return $form;
@@ -2951,16 +2942,7 @@ function fetchit_get_existing_selection_nid($db_handle, $db_type, $nid) {
           case 'copy_single':
             // radio button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
-            if (strlen($table_selection_table)) {
-              switch ($table_selection_table[0]) {
-                case '-':
-                case '*':
-                case '+':
-                  $table_selection_table = substr($table_selection_table, 1);
-                  break;
-                default:
-              }
-            }
+            $table_selection_table = fetchit7_strip_special_char_default($table_selection_table);
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_get_existing_selection_single($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field);
@@ -2970,16 +2952,7 @@ function fetchit_get_existing_selection_nid($db_handle, $db_type, $nid) {
           case 'copy_multiple':
             // check boxes button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
-            if (strlen($table_selection_table)) {
-              switch ($table_selection_table[0]) {
-                case '-':
-                case '*':
-                case '+':
-                  $table_selection_table = substr($table_selection_table, 1);
-                  break;
-                default:
-              }
-            }
+            $table_selection_table = fetchit7_strip_special_char_default($table_selection_table);
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_get_existing_selection_multiple($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field);
@@ -3007,16 +2980,7 @@ function fetchit_set_existing_selection_nid($db_handle, $db_type, $nid, $val) {
           case 'copy_single':
             // radio button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
-            if (strlen($table_selection_table)) {
-              switch ($table_selection_table[0]) {
-                case '-':
-                case '*':
-                case '+':
-                  $table_selection_table = substr($table_selection_table, 1);
-                  break;
-                default:
-              }
-            }
+            $table_selection_table = fetchit7_strip_special_char_default($table_selection_table);
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_set_existing_selection_single($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field, $val);
@@ -3026,16 +2990,7 @@ function fetchit_set_existing_selection_nid($db_handle, $db_type, $nid, $val) {
           case 'copy_multiple':
             // check boxes button record selection
             $table_selection_table = trim(fetchit7_content_field_fetcher($nid, 'table_selection_table', 'value'));
-            if (strlen($table_selection_table)) {
-              switch ($table_selection_table[0]) {
-                case '-':
-                case '*':
-                case '+':
-                  $table_selection_table = substr($table_selection_table, 1);
-                  break;
-                default:
-              }
-            }
+            $table_selection_table = fetchit7_strip_special_char_default($table_selection_table);
             $user_uid_field = trim(fetchit7_content_field_fetcher($nid, 'uid_field', 'value'));
             $key_field = trim(fetchit7_content_field_fetcher($nid, 'key_field', 'value'));
             $result = fetchit_set_existing_selection_multiple($db_handle, $db_type, $table_selection_table, $key_field, $user_uid_field, $val);
@@ -5720,4 +5675,34 @@ function fetchit7_get_control_list_string() {
     ++$count;
   }
   return $control_list_string;
+}
+
+function fetchit7_strip_special_char_default($val) {
+  $newval=$val;
+  if (strlen($val)) {
+    switch ($val[0]) {
+      case '-':
+      case '*':
+      case '+':
+        $newval = substr($val, 1);
+        break;
+      default:
+    }
+  }
+  return $newval;
+}
+
+function fetchit7_get_special_char_default($val) {
+  $special_char = '';
+  if (strlen($val)) {
+    switch ($val[0]) {
+      case '-':
+      case '*':
+      case '+':
+        $special_char = $val[0];
+        break;
+      default:
+    }
+  }
+  return $special_char;
 }

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -241,15 +241,14 @@ function fetchit7_table_form($form, &$form_state) {
   $all_selections = array();
   $first_selection = null;
   $first_selections = array();
-  // create the render arrays for each case
+  /*
+   * create the render arrays for each case
+   */
   switch ($table_selection_type) {
-    case 'copy_single':
-      // single row selection and key field copy via radio buttons
-    case 'copy_multiple':
-      // multiple row selection and key field copy via check boxes
-    case 'delete_multiple':
-      // multiple row selection and record deletion via check boxes
-      // create the HTML tableselect header and options
+  	// for all three of these cases, use the HTML tableselect header and options
+    case 'copy_single': // single row selection and key field copy via radio buttons
+    case 'copy_multiple': // multiple row selection and key field copy via check boxes
+    case 'delete_multiple': // multiple row selection and record deletion via check boxes
       $header = array();
       $options = array();
       for ($row_ndx = 0; $row_ndx < $row_count; $row_ndx++) {
@@ -265,12 +264,12 @@ function fetchit7_table_form($form, &$form_state) {
             if ($field_ndx == ($key_field_ndx - 1)) {
               // use this as the key for the options array
               $options_key = $db_value;
-              // its the index field
+              // it's the index field
               $all_selections[$db_value] = TRUE;
             }
             else {
               if ($row_ndx == 0) {
-                // its the first row
+                // it's the first row
                 $first_selection = $db_value;
                 $first_selections[$db_value] = TRUE;
                 if ($column_count < $table_headers_count) {
@@ -285,7 +284,7 @@ function fetchit7_table_form($form, &$form_state) {
             }
           }
         }
-        if (is_null($options_key)) {// selection enabled but no key field given - shame on you, user!!
+        if (is_null($options_key)) { // selection enabled but no key field given - shame on you, user!!
           $options_key = $row_ndx;
         }
         $options[$options_key] = $row;
@@ -347,11 +346,14 @@ function fetchit7_table_form($form, &$form_state) {
           break;
         default:
           $default_value = null;
-      } 
-      debug($default_value,'$default_value');
-      // create the HTML tableselect render array with a single select option
+      }
+      // check the default value created
+      // debug($default_value, '$default_value');
+      /* 
+       * create the HTML tableselect render array with a single select option
+       */
       $form['table'] = array(
-      	'#type' => 'tableselect',
+		'#type' => 'tableselect',
       	'#header' => $header,
       	'#options' => $options,
       	'#default_value' => $default_value,
@@ -359,15 +361,13 @@ function fetchit7_table_form($form, &$form_state) {
       	'#js_select' => $selectall_flag,
       	'#empty' => $table_empty_message,
       	'#weight' => $table_weight,
-			);
-	//no submit button if table is empty
-	//if ($row_count==0) $submit_button_flag = FALSE;
+	  );
+	  // no submit button if table is empty
+	  // if ($row_count==0) $submit_button_flag = FALSE;
       break;
-
+    // for all other cases, create a simple html table (NOT a tableselect)
     case 'none':
-    // simple html table display
     default:
-      // create the simple HTML table header and rows
       $header = array();
       $rows = array();
       for ($row_ndx = 0; $row_ndx < $row_count; $row_ndx++) {
@@ -392,9 +392,16 @@ function fetchit7_table_form($form, &$form_state) {
         }
         $rows[] = $row;
       }
-
-      // create the HTML table render array
-      $form['table'] = array('#theme' => 'table', '#header' => $header, '#rows' => $rows, '#empty' => $table_empty_message, '#weight' => $table_weight, );
+      /*
+       * create the simple HTML table render array
+       */
+      $form['table'] = array(
+      		'#theme' => 'table',
+      		'#header' => $header,
+      		'#rows' => $rows,
+      		'#empty' => $table_empty_message,
+      		'#weight' => $table_weight,
+      );
   }
 
   // append record elements
@@ -413,11 +420,11 @@ function fetchit7_table_form($form, &$form_state) {
   }
 
   if ($addbody_flag) {
-	  $body = fetchit7_content_field_fetcher($nid, 'body', 'value');
-		$form['body'] = array('#type' => 'markup', '#markup' => $body, );
-	}
+    $body = fetchit7_content_field_fetcher($nid, 'body', 'value');
+    $form['body'] = array('#type' => 'markup', '#markup' => $body, );
+  }
 
- 	$form['submit_button_flag'] = array('#type' => 'value', '#value' => $submit_button_flag, );
+  $form['submit_button_flag'] = array('#type' => 'value', '#value' => $submit_button_flag, );
   if ($submit_button_flag) {
     $form['submit'] = array('#type' => 'submit', '#value' => $submit_label, '#weight' => $submit_weight, );
   }
@@ -669,6 +676,7 @@ function fetchit7_param_form($form, &$form_state) {
 
   // get nid embedded into original form_id; format fetchit7_param_form_X### - nid starts at character 21
   $form_id = $form_state['build_info']['form_id'];
+  debug($form_id, microtime(true).' fetchit7_param_form: $form_id:');
   // to get here, this is definitely set
   //debug($form_state['build_info']);
   $nid = (int) substr($form_id, 21);
@@ -1309,11 +1317,11 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 	 *     that way, the form redrawing code does not have to be very smart
 	 */
 	if(isset($form_state['triggering_element'])) {
-		debug($form_state['triggering_element']['#name'],'fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
+		debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
 		// blow up the element name to get the info out of it
 		$element_name_components = array();
 		$element_name_components = explode('_',$form_state['triggering_element']['#name']);
-		debug($element_name_components,'fetchit7_param_form_force_triggering_element: element name components:');
+		debug($element_name_components,microtime(true).' fetchit7_param_form_force_triggering_element: element name components:');
 		// create an internal drupal variable with the same name as the element, give it a boolean value of true
 		// this can be used to let the subsequent (re)render of the form know what just happened!
 		variable_set($form_state['triggering_element']['#name'],TRUE);
@@ -1321,13 +1329,13 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 		$param_count = $form['param_count']['#value'];
 		for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
 			$element_name = $element_name_components[0].'_'.$element_name_components[1].'_'.$element_name_components[2].'_'.$element_name_components[3].'_'.$param_ndx;
-			debug($element_name,'fetchit7_param_form_element: element name:');
+			debug($element_name,microtime(true).' fetchit7_param_form_element: element name:');
 			variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
-			debug($form_state['values']['elements'][$element_name],'fetchit7_param_form_element: element value:');
+			debug($form_state['values']['elements'][$element_name],microtime(true).' fetchit7_param_form_element: element value:');
 		}
 		$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 	} else {
-		//debug($form_state['triggering_element']['#name'],'Hello from the fetchit7_param_form_force_triggering_element function. element name:');
+		debug('',microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is NOT set');
 	}
 	/*
 	if (isset($form_state['input']['all'])) {
@@ -1358,20 +1366,20 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
  * Process form validation
  */
 function fetchit7_param_all_validate($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'fetchit7_param_all_validate function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_all_validate function. triggering element variable value:');
+	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_validate function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_validate function. triggering element variable value:');
 	drupal_set_message(t('Successfully validated all button.'), 'status');
 }
 
 function fetchit7_param_none_validate($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'fetchit7_param_none_validate function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_none_validate function: triggering element variable value:');
+	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_validate function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_validate function: triggering element variable value:');
 	drupal_set_message(t('Successfully validated none button.'), 'status');
 }
 
 function fetchit7_param_form_validate($form, &$form_state) {
 	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,'fetchit7_param_form_validate function. $form[] param_count or $form_state[]:');
+	debug($string,microtime(true).' fetchit7_param_form_validate function. $form[] param_count or $form_state[]:');
 	$nid = $form['nid']['#value'];
 	//$row_ndx = 0;
 	//$param_ndx = 0;
@@ -1383,14 +1391,14 @@ function fetchit7_param_form_validate($form, &$form_state) {
 }
 
 function fetchit7_param_all_submit($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'fetchit7_param_all_submit function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_all_submit function: triggering element variable value:');
+	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_all_submit function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_all_submit function: triggering element variable value:');
 	drupal_set_message(t('Successfully submitted all button.'), 'status');
 }
 
 function fetchit7_param_none_submit($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'fetchit7_param_none_submit function: triggering element:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_none_submit function: triggering element variable value:');
+	debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_none_submit function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),microtime(true).' fetchit7_param_none_submit function: triggering element variable value:');
 	drupal_set_message(t('Successfully submitted none button.'), 'status');
 }
 
@@ -1506,13 +1514,14 @@ function fetchit7_param_form_submit($form, &$form_state) {
     }
   }
 
-  drupal_set_message(t('Successfully submitted changes.'), 'status');
+  drupal_set_message(t('Successfully submitted changes at '.microtime(true)), 'status');
 }
 
 function theme_fetchit7_param_form($variables) {
   $form = $variables['form'];
   $nid = $form['nid']['#value'];
   $form_id = $form['form_id']['#value'];
+  debug($form_id, microtime(true).' theme_fetchit7_param_form: $form_id:');
   //the drupal way is to do all the non display related preprocessing in a theme preprocessor function
   // ... move it there later ...
   $table_row_count = $form['table_rows']['#value'];

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1155,30 +1155,36 @@ function fetchit7_param_form($form, &$form_state) {
         switch ($user_field_data[$i][F_DR_FIELD_INPUT_TYPE_STR]) {
           case F_DR_CONTROL_CHECKBOXES:
           case F_DR_CONTROL_DROPDOWN_MULTI:
+          	// first get the previously saved state...
             $db_value = fetchit_get_existing_selection_multiple($db_handle, $db_type, $data_tbl, $data_ndx, $data_uid);
-            //check to see if there is an "interim state" we need to reset the control too
-	        //(in other words, the user hit a select All or select None button)
-	        //see if there is a stored variable with the name element_name_value
-			if (variable_get($element_name.'_value',FALSE)) {
+			debug($db_value,microtime(true).' creating form element '.$element_name.'. Default value set to');
+            // next, check to see if there is an "interim state" to reset the control too
+	        //   (this happens when the user presses a select All or select None button)
+	        //   see if there is a stored variable with the name element_name_value
+			if (variable_get($element_name.'_set',FALSE)) {
 				// need to reset this control to an interim saved state
-				// set the default string to '' and then set the $db_value to the interim state
-        		$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]='';
-				debug(variable_get($element_name.'_value',FALSE),'saved element '.$element_name.' value is:');
-				$db_value = variable_get($element_name.'_value',FALSE);
+				// set the default string to FETCHIT7_FIELD_DEFAULT_PREVIOUS
+				//    and then set $db_value to the interim state, overwriting the previously selected state
+				//    then set the $user_field_data[] flag so that the fetchit 2 routines will use it,
+				//  essentially this is fooling the fetchit2 routines into thinking the interim state
+				//    is the previously selected state
+        		$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_PREVIOUS;
+				$db_value = variable_get($element_name.'_value','');
+			    debug($db_value,microtime(true).' creating form element '.$element_name.'. RESETTING default value to');
 				//and then finally erase the interim state flag...
-				variable_set($element_name.'_value',NULL);
+				variable_set($element_name.'_set',FALSE);
 			}
-            // also here is where we change the default if the all or none buttons were pressed
+            // finally, here is where we change the default if the all or none buttons were pressed for this element
             //   for this particular element
+            // at most only one of these should be true, but handle both separately so they get reset correctly,
+            //   just in case...
             if (variable_get($element_name.'_allbtn',FALSE)) {
             	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_ALL;
-            	//do the following in the submit button submit function
-            	//variable_set($element_name.'_allbtn',FALSE);
+            	variable_set($element_name.'_allbtn',FALSE);
             }
             if (variable_get($element_name.'_nonebtn',FALSE)) {
             	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_NONE;
-            	//do the following in the submit button submit function
-            	//variable_set($element_name.'_nonebtn',FALSE);
+            	variable_set($element_name.'_nonebtn',FALSE);
             }
             // only need to make these if it is this type of control
             // be sure to check isset in theme function, though
@@ -1217,6 +1223,24 @@ function fetchit7_param_form($form, &$form_state) {
           case F_DR_CONTROL_DATETIMESEL:
           case F_DR_CONTROL_POPUPDATE:
             $db_value = fetchit_get_existing_selection_single($db_handle, $db_type, $data_tbl, $data_ndx, $data_uid);
+
+            debug($db_value,microtime(true).' creating form element '.$element_name.'. Default value set to');
+            // next, check to see if there is an "interim state" to reset the control too
+            //   (this happens when the user presses a select All or select None button)
+            //   see if there is a stored variable with the name element_name_value
+            if (variable_get($element_name.'_set',FALSE)) {
+            	// need to reset this control to an interim saved state
+            	// set the default string to FETCHIT7_FIELD_DEFAULT_PREVIOUS
+            	//    and then set $db_value to the interim state, overwriting the previously selected state
+            	//    then set the $user_field_data[] flag so that the fetchit 2 routines will use it,
+            	//  essentially this is fooling the fetchit2 routines into thinking the interim state
+            	//    is the previously selected state
+            	$user_field_data[$i][F_DR_FIELD_DEFAULT_STR]=FETCHIT7_FIELD_DEFAULT_PREVIOUS;
+            	$db_value = variable_get($element_name.'_value','');
+            	debug($db_value,microtime(true).' creating form element '.$element_name.'. RESETTING default value to');
+            	//and then finally erase the interim state flag...
+            	variable_set($element_name.'_set',FALSE);
+            }
             break;
           default:
         }
@@ -1233,12 +1257,22 @@ function fetchit7_param_form($form, &$form_state) {
         $form['param_data_table'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][F_DR_FIELD_DATA_TBL_STR]);
         $form['param_data_ndx'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][F_DR_FIELD_DATA_KEY_STR]);
         $form['param_data_uid'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][F_DR_FIELD_DATA_UID_STR]);
+        // note that for the following - would like to eventually add the option for the all none buttons to be added automatically based on the size of the list
         $form['param_allnone'][$param_count] = array('#type' => 'value', '#value' => $user_field_data[$i][FETCHIT7_ALLNONE_SPECIAL_CHAR_STR]);
         
         // the following creates the "renderable array" of the next parameter input control (drupal form element)
         //   to be displayed on this form ($nid)
         // stack these up in the array. "How" they are to be displayed will be handled by the theme function
-        $form['elements'][$element_name] = fetchit7_param_element_form($param_name, $data_tbl_ndx_type, $db_handle, $i + 1, $user_field_data, $nid, $showtitles, $db_value);
+        $form['elements'][$element_name] = 
+        	fetchit7_param_element_form(
+        			$param_name,
+        			$data_tbl_ndx_type,
+        			$db_handle,
+        			$i + 1,
+        			$user_field_data,
+        			$nid,
+        			$showtitles,
+        			$db_value);
         //debug($myform[$element_name],' pre-render $myform['.$element_name.']');
         $param_count++;
       }
@@ -1319,22 +1353,31 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 	 *     that way, the form redrawing code does not have to be very smart
 	 */
 	if(isset($form_state['triggering_element'])) {
-		debug($form_state['triggering_element']['#name'],microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
+		$triggering_element_name = $form_state['triggering_element']['#name'];
+		debug($triggering_element_name,microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
 		// blow up the element name to get the info out of it
-		$element_name_components = array();
-		$element_name_components = explode('_',$form_state['triggering_element']['#name']);
-		debug($element_name_components,microtime(true).' fetchit7_param_form_force_triggering_element: element name components:');
-		// create an internal drupal variable with the same name as the element, give it a boolean value of true
-		// this can be used to let the subsequent (re)render of the form know what just happened!
-		variable_set($form_state['triggering_element']['#name'],TRUE);
-		//save the existing state of all the form elements
+		$triggering_element_name_components = array();
+		$triggering_element_name_components = explode('_',$triggering_element_name);
+		debug($triggering_element_name_components,microtime(true).' fetchit7_param_form_force_triggering_element: element name components:');
+		//save the existing state of ALL the form elements
 		$param_count = $form['param_count']['#value'];
 		for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
 			$element_name = $element_name_components[0].'_'.$element_name_components[1].'_'.$element_name_components[2].'_'.$element_name_components[3].'_'.$param_ndx;
 			debug($element_name,microtime(true).' fetchit7_param_form_element: element name:');
+			variable_set($element_name.'_set',true);
 			variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
 			debug($form_state['values']['elements'][$element_name],microtime(true).' fetchit7_param_form_element: element value:');
+			// set them all to false, then set the triggering to true afterwards
+			// notice that $element_name (the value/list control) is the base of $triggering_element_name (the all or none button)
+			variable_set($element_name.'_allbtn',false);
+			variable_set($element_name.'_nonebtn',false);
 		}
+		// create an internal drupal variable with the same name as the element, give it a boolean value of true
+		// this is used to let the subsequent (re)render of the form know that it is redrawing
+		//   after an all or none button press, because things happen differently in those cases
+		variable_set($triggering_element_name,true);
+		
+		// what is this for?
 		$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 	} else {
 		debug('',microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is NOT set');
@@ -4110,17 +4153,17 @@ function fetchit_get_checkboxes_element($user_field_data, $user_field_ndx, $db_h
 				foreach ($db_values as $db_value) {
 					if (in_array($db_value, $options_keys)) {
 						$found_values[] = $db_value;
-		    	}
+					}
 				}
 				$defaults = $found_values;
 			} else {
-		    $defaults = array();
+				$defaults = array();
 			}
 		} else {
-	    $defaults = array();
+			$defaults = array();
 		}
-  } else {
-    $defaults = array();
+	} else {
+		$defaults = array();
 	}
 	
   // then set up the defaults based on the string they typed into the defaults attribute box

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1290,18 +1290,40 @@ function fetchit7_param_form($form, &$form_state) {
   return $form;
 }
 
+//this function is called before drupal processes the form submit hook
 function fetchit7_param_form_force_triggering_element($form, &$form_state) {
-	if(isset($form_state['triggering_element']['#name'])) {
-		debug($form_state['triggering_element']['#name'],'Hello from the fetchit7_param_form_force_triggering_element function. element name:');
+	/*
+	 * the triggering element variable gets set based on which button was pressed
+	 * the idea is that it is set (has a value) right after the button is pressed,
+	 *   but NOT later (in the drupal form processing) when this function seems to get called again
+	 *   so checking with isset() is a way to add some code to fire RIGHT AFTER an all or nothing button is pressed
+	 *   but we want this function to do nothing on other calls
+	 *   the code we want to add should save in a drupal variable which button was pressed
+	 *     and clear out all the other button press saves so only one is ever set at a time
+	 *     then when the form is drawn it can look for this variable and set the default values accordingly
+	 *     also, we will have to save any changes the user has made to other form elements
+	 *     and restore them when the form is redrawn.
+	 *     this means essentially that EVERY form element will need to have it's state saved
+	 *     so it can be restored when the form is redrawn.  the one form element associated with the all or none
+	 *     button pressed will not save it's current state, but will save either a all or none state
+	 *     that way, the form redrawing code does not have to be very smart
+	 */
+	if(isset($form_state['triggering_element'])) {
+		debug($form_state['triggering_element']['#name'],'fetchit7_param_form_force_triggering_element: a triggering_element is set; the name is:');
+		// blow up the element name to get the info out of it
 		$element_name_components = array();
 		$element_name_components = explode('_',$form_state['triggering_element']['#name']);
-		debug($element_name_components,'Hello from the fetchit7_param_form_force_triggering_element function. element name components:');
+		debug($element_name_components,'fetchit7_param_form_force_triggering_element: element name components:');
+		// create an internal drupal variable with the same name as the element, give it a boolean value of true
+		// this can be used to let the subsequent (re)render of the form know what just happened!
 		variable_set($form_state['triggering_element']['#name'],TRUE);
 		//save the existing state of all the form elements
 		$param_count = $form['param_count']['#value'];
 		for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
 			$element_name = $element_name_components[0].'_'.$element_name_components[1].'_'.$element_name_components[2].'_'.$element_name_components[3].'_'.$param_ndx;
+			debug($element_name,'fetchit7_param_form_element: element name:');
 			variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
+			debug($form_state['values']['elements'][$element_name],'fetchit7_param_form_element: element value:');
 		}
 		$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 	} else {
@@ -1336,20 +1358,20 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
  * Process form validation
  */
 function fetchit7_param_all_validate($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'Hello from the parameter all validate function. From here the triggering element is:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter all validate function. From here the triggering element is:');
-	drupal_set_message(t('Successfully validated all.'), 'status');
+	debug($form_state['triggering_element']['#name'],'fetchit7_param_all_validate function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_all_validate function. triggering element variable value:');
+	drupal_set_message(t('Successfully validated all button.'), 'status');
 }
 
 function fetchit7_param_none_validate($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'Hello from the parameter none validate function. From here the triggering element is:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter none validate function. From here the triggering element is:');
-	drupal_set_message(t('Successfully validated none.'), 'status');
+	debug($form_state['triggering_element']['#name'],'fetchit7_param_none_validate function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_none_validate function: triggering element variable value:');
+	drupal_set_message(t('Successfully validated none button.'), 'status');
 }
 
 function fetchit7_param_form_validate($form, &$form_state) {
 	$string = $form['param_count']['#value'].' or '.$form_state['values']['param_count'];
-	debug($string,'Hello from the all important parameter input form validate function. From here it appears the param_count is:');
+	debug($string,'fetchit7_param_form_validate function. $form[] param_count or $form_state[]:');
 	$nid = $form['nid']['#value'];
 	//$row_ndx = 0;
 	//$param_ndx = 0;
@@ -1361,15 +1383,15 @@ function fetchit7_param_form_validate($form, &$form_state) {
 }
 
 function fetchit7_param_all_submit($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'Hello from the parameter all submit function. From here the triggering element is:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter all submit function. From here the triggering element is:');
-	drupal_set_message(t('Successfully selected all.'), 'status');
+	debug($form_state['triggering_element']['#name'],'fetchit7_param_all_submit function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_all_submit function: triggering element variable value:');
+	drupal_set_message(t('Successfully submitted all button.'), 'status');
 }
 
 function fetchit7_param_none_submit($form, &$form_state) {
-	debug($form_state['triggering_element']['#name'],'Hello from the parameter none submit function. From here the triggering element is:');
-	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'Hello from the parameter none submit function. From here the triggering element is:');
-	drupal_set_message(t('Successfully selected none.'), 'status');
+	debug($form_state['triggering_element']['#name'],'fetchit7_param_none_submit function: triggering element:');
+	debug(variable_get($form_state['triggering_element']['#name'],FALSE),'fetchit7_param_none_submit function: triggering element variable value:');
+	drupal_set_message(t('Successfully submitted none button.'), 'status');
 }
 
 /**

--- a/fetchit7.forms.inc
+++ b/fetchit7.forms.inc
@@ -1359,26 +1359,28 @@ function fetchit7_param_form_force_triggering_element($form, &$form_state) {
 		$triggering_element_name_components = array();
 		$triggering_element_name_components = explode('_',$triggering_element_name);
 		debug($triggering_element_name_components,microtime(true).' fetchit7_param_form_force_triggering_element: element name components:');
-		//save the existing state of ALL the form elements
-		$param_count = $form['param_count']['#value'];
-		for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
-			$element_name = $element_name_components[0].'_'.$element_name_components[1].'_'.$element_name_components[2].'_'.$element_name_components[3].'_'.$param_ndx;
-			debug($element_name,microtime(true).' fetchit7_param_form_element: element name:');
-			variable_set($element_name.'_set',true);
-			variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
-			debug($form_state['values']['elements'][$element_name],microtime(true).' fetchit7_param_form_element: element value:');
-			// set them all to false, then set the triggering to true afterwards
-			// notice that $element_name (the value/list control) is the base of $triggering_element_name (the all or none button)
-			variable_set($element_name.'_allbtn',false);
-			variable_set($element_name.'_nonebtn',false);
+		if ($triggering_element_name_components[0]=="fetchit7") {
+			//save the existing state of ALL the form elements
+			$param_count = $form['param_count']['#value'];
+			for ($param_ndx = 0; $param_ndx < $param_count; $param_ndx++) {
+				$element_name = $triggering_element_name_components[0].'_'.$triggering_element_name_components[1].'_'.$triggering_element_name_components[2].'_'.$triggering_element_name_components[3].'_'.$param_ndx;
+				debug($element_name,microtime(true).' fetchit7_param_form_element: element name:');
+				variable_set($element_name.'_set',true);
+				variable_set($element_name.'_value',$form_state['values']['elements'][$element_name]);
+				debug($form_state['values']['elements'][$element_name],microtime(true).' fetchit7_param_form_element: element value:');
+				// set them all to false, then set the triggering to true afterwards
+				// notice that $element_name (the value/list control) is the base of $triggering_element_name (the all or none button)
+				variable_set($element_name.'_allbtn',false);
+				variable_set($element_name.'_nonebtn',false);
+			}
+			// create an internal drupal variable with the same name as the element, give it a boolean value of true
+			// this is used to let the subsequent (re)render of the form know that it is redrawing
+			//   after an all or none button press, because things happen differently in those cases
+			variable_set($triggering_element_name,true);
+			
+			// what is this for?
+			$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 		}
-		// create an internal drupal variable with the same name as the element, give it a boolean value of true
-		// this is used to let the subsequent (re)render of the form know that it is redrawing
-		//   after an all or none button press, because things happen differently in those cases
-		variable_set($triggering_element_name,true);
-		
-		// what is this for?
-		$form_state['triggering_element'] = $form['elements'][$form_state['triggering_element']['#name']];
 	} else {
 		debug('',microtime(true).' fetchit7_param_form_force_triggering_element: a triggering_element is NOT set');
 	}


### PR DESCRIPTION
the table select forms now can remember the previous selection.  since they have a nice javascript interface for toggling select all or select none, they are ideal for single selection forms with long lists.

the param forms are for multiple selections on one form which can either be stacked or in a table format.  each one has a table for a source and also a table for a destination.  I added the ability for multiselect controls to have all and none buttons added

this is all done via tricks, not settings, because I don't want to require uninstalling and reinstalling fetchit.  that will mess up existing sites with fetchit.  this way the code in fetchit7.forms.inc and fetchit7.constants.inc can just be overwritten on the existing sites.

one such trick is using special first characters (+ - *) on the selection output table name.
